### PR TITLE
:bug: fix: use int for admin users in config setup

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -175,9 +175,7 @@ def advanced_setup():
         if choice != "":
             admins = choice.replace(" ", "").split(",")
             try:
-                for admin in admins:
-                    admin = int(admin)
-                _global_config["bot"]["admins"] = admins
+                _global_config["bot"]["admins"] = [int(admin_id) for admin_id in admins]
             except ValueError:
                 print(
                     f"{color.fg.red}👑 Invalid entry. Only user ID (integers),"\


### PR DESCRIPTION
During the guided configuration setup process, the administrator user IDs are currently stored as strings, which make them unusable in the bot code (as they are then compared and treated as integers).

This PR fixes the configuration setup script. Affected configuration files will have to be manually fixed.