### PR TITLE
:memo: feat: update funding url to our custom page

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-patreon: gunivers
+custom: https://altearn.xyz/soutenir/


### PR DESCRIPTION
The current funding link redirects to the Gunivers' patreon page, which is not used anymore. This PR updates the funding link to redirect people to our Altearn donation page, which currently uses HelloAsso.