### PR TITLE
Fix admin commands

### DIFF
--- a/plugins/admin/admin.py
+++ b/plugins/admin/admin.py
@@ -143,10 +143,10 @@ class Admin(commands.Cog):
         errors_cog = self.bot.get_cog("Errors")
         if len(cogs) == 1 and cogs[0] == "all":
             cogs = sorted([x.file for x in self.bot.cogs.values()])
-        reloaded_cogs = list()
+        reloaded_cogs = []
         for cog in cogs:
             try:
-                self.bot.reload_extension("plugins." + cog + ".bot.main")
+                await self.bot.reload_extension("plugins." + cog + '.' + cog)
             except ModuleNotFoundError:
                 await ctx.send(f"Cog {cog} can't be found")
             except commands.errors.ExtensionNotLoaded:
@@ -167,7 +167,7 @@ class Admin(commands.Cog):
     async def add_cog(self, ctx: commands.Context, name: str):
         """Ajouter un cog au bot"""
         try:
-            self.bot.load_extension("plugins." + name)
+            await self.bot.load_extension("plugins." + name + '.' + name)
             await ctx.send(f"Module '{name}' ajouté !")
             self.bot.log.info(f"Module {name} ajouté")
         except Exception as exc: # pylint: disable=broad-exception-caught
@@ -177,7 +177,7 @@ class Admin(commands.Cog):
     async def rm_cog(self, ctx: commands.Context, name: str):
         """Enlever un cog au bot"""
         try:
-            self.bot.unload_extension("plugins." + name)
+            await self.bot.unload_extension("plugins." + name + '.' + name)
             await ctx.send(f"Module '{name}' désactivé !")
             self.bot.log.info(f"Module {name} désactivé")
         except Exception as exc: # pylint: disable=broad-exception-caught

--- a/plugins/admin/admin.py
+++ b/plugins/admin/admin.py
@@ -104,7 +104,10 @@ class Admin(commands.Cog):
         await self.bot.close()
 
     async def cleanup_workspace(self):
+        "Delete python cache files"
         for folder_name, _, filenames in os.walk(".."):
+            if folder_name.startswith("./env") or folder_name.startswith("./venv"):
+                continue
             for filename in filenames:
                 if filename.endswith(".pyc"):
                     os.unlink(folder_name + "/" + filename)


### PR DESCRIPTION
This PR should fix two bugs related to admin commands:
- the `reload`/`add_cog`/`del_cog` didn't await the lib coroutines and were thus not reloading anything (+ they used the old plugin structure format)
- the `shutdown` command, when trying to remove `__pycache__` files, was also deleting cache in the environment folder, thus failing for a few libs that actually used these folders