### PR TITLE
🐛 Fix error with logs enable

### DIFF
--- a/plugins/logs/logs.py
+++ b/plugins/logs/logs.py
@@ -106,7 +106,7 @@ class Logs(commands.Cog):
 
     def get_flags(self, guild_id):
         """Return the log flags for a the given `guild_id`."""
-        flags = self.bot.get_cog('ConfigCog').LogsFlags().int_to_flags()
+        flags = self.bot.get_cog('ConfigCog').LogsFlags().int_to_flags
         return flags(self.bot.server_configs[guild_id]['modlogs_flags'])
 
     @commands.Cog.listener()


### PR DESCRIPTION
Cette PR résout une erreur affichée avec les logs d'activés :

```
Traceback (most recent call last):
  File "/home/ascpial/Projets/Gipsy/venv/lib64/python3.11/site-packages/discord/client.py", line 441, in _run_event
    await coro(*args, **kwargs)
  File "/home/ascpial/Projets/Gipsy/plugins/logs/logs.py", line 552, in on_member_update
    if 'members' not in self.get_flags(before.guild.id):
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ascpial/Projets/Gipsy/plugins/logs/logs.py", line 109, in get_flags
    flags = self.bot.get_cog('ConfigCog').LogsFlags().int_to_flags()
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: ConfigCog.LogsFlags.int_to_flags() missing 1 required positional argument: 'i'
```