### PR TITLE
🐛 Fix missing translations for rolelink

### DIFF
--- a/plugins/roleLink/langs/en.yml
+++ b/plugins/roleLink/langs/en.yml
@@ -1,0 +1,8 @@
+en:
+  grouproles:
+    dep-added: A new dependency has been added, with the ID %{id}
+    dep-deleted: Your role-link has been removed
+    dep-notfound: Cannot find a role-link with this identifier. You can get the identifier of a link with the `%{p}rolelink list` command
+    infinite: "Oops, it seems that this dependency can lead to an infinite loop with at least the following dependency: \"%{dep}\"\nIf you're sure you want to continue, enter 'yes' in the next %{t} seconds..."
+    list: "List of your roles-links:"
+    no-dep: "You do not have any dependencies configured at the moment.\nUse the `%{p}rolelink create` command to add more dependencies"

--- a/plugins/roleLink/langs/fr.yml
+++ b/plugins/roleLink/langs/fr.yml
@@ -1,0 +1,8 @@
+fr:
+  grouproles:
+    dep-added: Une nouvelle dépendance a été ajoutée, avec l'ID %{id}
+    dep-deleted: Votre rôle-liaison a bien été supprimée
+    dep-notfound: Impossible de trouver une rôle-liaison avec cet identifiant.\nVous pouvez obtenir l'identifiant d'une liaison avec la commande `%{p}rolelink list`
+    infinite: "Oups, il semble que cette dépendance puisse entraîner une boucle infinie avec au moins la dépendance suivante : \"%{dep}\"\nSi vous êtes sûr de vouloir continuer, entrez 'oui' dans les %{t} prochaines secondes"
+    list: "Liste de vos rôles-liaisons :"
+    no-dep: "Vous n'avez aucune dépendance de configurée pour le moment.\nUtilisez la commande `%{p}rolelink create` pour en ajouter"

--- a/plugins/roleLink/roleLink.py
+++ b/plugins/roleLink/roleLink.py
@@ -78,7 +78,7 @@ class Dependency:
         triggers = " ".join([f"<@&{r}>" for r in self.trigger_roles])
         target = f"<@&{self.target_role}>"
         depedency_id = f"{self.dependency_id}. " if user_id else ""
-        return f"{depedency_id}{self.action.name} {target} when"\
+        return f"{depedency_id}{self.action.name} {target} when "\
             f"{self.trigger.name.replace('-', ' ')} of {triggers}"
 
 

--- a/plugins/roleLink/roleLink.py
+++ b/plugins/roleLink/roleLink.py
@@ -5,16 +5,16 @@ utiliser, modifier et/ou redistribuer ce programme sous les conditions
 de la licence CeCILL diffusée sur le site "http://www.cecill.info".
 """
 
-from typing import List, Union
-from marshal import dumps, loads
 import asyncio
+from marshal import dumps, loads
+from typing import List, Optional, Union
 
-from discord.ext import commands
 import discord
+from discord.ext import commands
 
 from bot import args
-from utils import Gunibot
 from core import setup_logger
+from utils import Gunibot
 
 # /rolelink <grant/revoke> <role> when <get/loose> <one/all> <roles>
 
@@ -72,7 +72,7 @@ class Dependency:
         self.trigger_roles = trigger_roles
         self.b_trigger_roles = dumps(trigger_roles)
         self.guild = guild
-        self.dependency_id = None
+        self.dependency_id: Optional[int] = None
 
     def to_str(self, user_id: bool = True) -> str:
         triggers = " ".join([f"<@&{r}>" for r in self.trigger_roles])
@@ -92,11 +92,11 @@ class GroupRoles(commands.Cog):
         self.logger = setup_logger('rolelink')
         self.file = ""
 
-    def db_get_config(self, guild_id: int) -> List[Dependency]:
+    def db_get_config(self, guild_id: int):
         """Get every dependencies of a specific guild"""
         query = "SELECT rowid, * FROM group_roles WHERE guild=?"
         # comes as: (rowid, guild, action, target, trigger, trigger-roles)
-        res = list()
+        res: list[Dependency] = []
         liste = self.bot.db_query(query, (guild_id,))
         for row in liste:
             temp = (
@@ -107,7 +107,7 @@ class GroupRoles(commands.Cog):
                 row["guild"],
             )
             res.append(Dependency(*temp))
-            res[-1].id = row["rowid"]
+            res[-1].dependency_id = row["rowid"]
         return res if len(res) > 0 else None
 
     def db_add_action(self, action: Dependency) -> int:


### PR DESCRIPTION
Lors de la migration des plugins depuis le repo secondaire au repo principal, les fichiers de traduction du plugin roleLink ont étés perdus.

Ils sont de retour, avec en plus un fix pour un espace manquant :

![image](https://github.com/Curiosity-org/Gipsy/assets/72463129/02d9c369-d104-45bd-a845-2a44df228ee9)

Fixes #169.