### PR TITLE
✨ feat: add youtube tracking remover

### DIFF
--- a/plugins/youtubeTrackingRemover/config/options.json
+++ b/plugins/youtubeTrackingRemover/config/options.json
@@ -1,0 +1,7 @@
+{
+  "enable_youtube_tracking_remover": {
+    "default": false,
+    "type": "boolean",
+    "command": "enable_youtube_tracking_remover"
+  }
+}

--- a/plugins/youtubeTrackingRemover/credits.md
+++ b/plugins/youtubeTrackingRemover/credits.md
@@ -1,0 +1,6 @@
+Copyright © Aeris One 2023
+
+Ce programme est régi par la licence CeCILL soumise au droit français et
+respectant les principes de diffusion des logiciels libres. Vous pouvez
+utiliser, modifier et/ou redistribuer ce programme sous les conditions
+de la licence CeCILL diffusée sur le site "http://www.cecill.info".

--- a/plugins/youtubeTrackingRemover/langs/en.yml
+++ b/plugins/youtubeTrackingRemover/langs/en.yml
@@ -1,0 +1,4 @@
+en:
+  youtube_tracking_remover:
+    button_label: 'What is this?'
+    message: 'Since summer 2023, YouTube links may contain tracking parameters. This message was re-sent because it used to contain a link with tracking parameters. Those tracking parameters have been removed and the link is now safe to click without YouTube knowing who sent this link.'

--- a/plugins/youtubeTrackingRemover/langs/en.yml
+++ b/plugins/youtubeTrackingRemover/langs/en.yml
@@ -1,4 +1,4 @@
 en:
   youtube_tracking_remover:
-    button_label: 'What is this?'
+    not_author: 'You are not the author of this message.'
     message: 'Since summer 2023, YouTube links may contain tracking parameters. This message was re-sent because it used to contain a link with tracking parameters. Those tracking parameters have been removed and the link is now safe to click without YouTube knowing who sent this link.'

--- a/plugins/youtubeTrackingRemover/langs/fr.yml
+++ b/plugins/youtubeTrackingRemover/langs/fr.yml
@@ -1,0 +1,4 @@
+fr:
+  youtube_tracking_remover:
+    button_label: "C'est quoi ça ?"
+    message: "Depuis l'été 2023, certains liens YouTube contiennent des paramètres de suivi afin d'identifier la personne ayant envoyé chaque lien. Ce message a été renvoyé car il contenait un lien avec ces paramètres. Ils ont été supprimés et le lien peut désormais être cliqué en toute sécurité sans que YouTube ne sache qui l'a envoyé."

--- a/plugins/youtubeTrackingRemover/langs/fr.yml
+++ b/plugins/youtubeTrackingRemover/langs/fr.yml
@@ -1,4 +1,4 @@
 fr:
   youtube_tracking_remover:
-    button_label: "C'est quoi ça ?"
+    not_author: "Vous n'êtes pas l'auteur de ce message."
     message: "Depuis l'été 2023, certains liens YouTube contiennent des paramètres de suivi afin d'identifier la personne ayant envoyé chaque lien. Ce message a été renvoyé car il contenait un lien avec ces paramètres. Ils ont été supprimés et le lien peut désormais être cliqué en toute sécurité sans que YouTube ne sache qui l'a envoyé."

--- a/plugins/youtubeTrackingRemover/youtubeTrackingRemover.py
+++ b/plugins/youtubeTrackingRemover/youtubeTrackingRemover.py
@@ -37,7 +37,7 @@ class YoutubeTrackingRemover(commands.Cog):
         if not message.guild:
             return
 
-        # check if server has enabled the abbreviation explainer
+        # check if server has enabled the youtube tracking remover
         if not self.bot.server_configs[message.guild.id].get("enable_youtube_tracking_remover", False):
             print("not enabled")
             return

--- a/plugins/youtubeTrackingRemover/youtubeTrackingRemover.py
+++ b/plugins/youtubeTrackingRemover/youtubeTrackingRemover.py
@@ -58,19 +58,22 @@ class YoutubeTrackingRemover(commands.Cog):
         for match in matches:
             parsed_url = urlparse(match)
             query_params = parse_qs(parsed_url.query)
+            new_match = match
 
             # replace the link with a link with only the video id
             if 'v' in query_params:
                 video_id = query_params['v'][0]
-                content = content.replace(match, f'https://www.youtube.com/watch?v={video_id}')
+                new_match = f'https://www.youtube.com/watch?v={video_id}'
 
             # re-add `time` and `t` parameters
             if 't' in query_params:
                 time = query_params['t'][0]
-                content = content.replace(match, f'{match}&t={time}')
+                new_match = new_match + f'&t={time}'
             elif 'time' in query_params:
                 time = query_params['time'][0]
-                content = content.replace(match, f'{match}&time={time}')
+                new_match = new_match + f'&time={time}'
+
+            content = content.replace(match, f'{new_match}')
 
         # check for youtu.be links
         regex = r'(https?://(?:www\.)?youtu\.be/[^\s]+)'
@@ -82,15 +85,17 @@ class YoutubeTrackingRemover(commands.Cog):
             query_params = parse_qs(parsed_url.query)
 
             # remove every parameters
-            match = match.split('?')[0]
+            new_match = match.split('?')[0]
 
             # re-add `time` and `t` parameters
             if 't' in query_params:
                 time = query_params['t'][0]
-                content = content.replace(match, f'{match}?t={time}')
+                new_match = new_match + f'?t={time}'
             elif 'time' in query_params:
                 time = query_params['time'][0]
-                content = content.replace(match, f'{match}?time={time}')
+                new_match = new_match + f'?time={time}'
+
+            content = content.replace(match, f'{new_match}')
 
         if content == message.content:
             # no need to send a message if it will be the same

--- a/plugins/youtubeTrackingRemover/youtubeTrackingRemover.py
+++ b/plugins/youtubeTrackingRemover/youtubeTrackingRemover.py
@@ -9,7 +9,6 @@ import discord
 from discord.ext import commands
 import re
 from urllib.parse import urlparse, parse_qs
-from typing import List, Tuple
 
 from utils import Gunibot, MyContext
 
@@ -123,6 +122,7 @@ class YoutubeTrackingRemoverView(discord.ui.View):
         super().__init__(timeout=None)
         self.bot = bot
 
+    # pylint: disable=unused-argument
     @discord.ui.button(emoji='❓', style=discord.ButtonStyle.green, custom_id="youtube_tracking_remover:button")
     async def button(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.send_message(await self.bot._(interaction.guild_id, "youtube_tracking_remover.message"),

--- a/plugins/youtubeTrackingRemover/youtubeTrackingRemover.py
+++ b/plugins/youtubeTrackingRemover/youtubeTrackingRemover.py
@@ -121,7 +121,7 @@ class YoutubeTrackingRemoverView(discord.ui.View):
         self.original_user_id = original_user_id
 
     # pylint: disable=unused-argument
-    @discord.ui.button(emoji='❓', style=discord.ButtonStyle.green)
+    @discord.ui.button(emoji='❔', style=discord.ButtonStyle.blurple)
     async def button(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.send_message(
             await self.bot._(interaction.guild_id, "youtube_tracking_remover.message"),

--- a/plugins/youtubeTrackingRemover/youtubeTrackingRemover.py
+++ b/plugins/youtubeTrackingRemover/youtubeTrackingRemover.py
@@ -39,7 +39,6 @@ class YoutubeTrackingRemover(commands.Cog):
 
         # check if server has enabled the youtube tracking remover
         if not self.bot.server_configs[message.guild.id].get("enable_youtube_tracking_remover", False):
-            print("not enabled")
             return
 
         # check if message is not from a bot

--- a/plugins/youtubeTrackingRemover/youtubeTrackingRemover.py
+++ b/plugins/youtubeTrackingRemover/youtubeTrackingRemover.py
@@ -1,0 +1,105 @@
+"""
+Ce programme est régi par la licence CeCILL soumise au droit français et
+respectant les principes de diffusion des logiciels libres. Vous pouvez
+utiliser, modifier et/ou redistribuer ce programme sous les conditions
+de la licence CeCILL diffusée sur le site "http://www.cecill.info".
+"""
+
+import discord
+from discord.ext import commands
+import re
+from urllib.parse import urlparse, parse_qs
+from typing import List, Tuple
+
+from utils import Gunibot, MyContext
+
+
+async def setup(bot: Gunibot = None):
+    await bot.add_cog(YoutubeTrackingRemover(bot))
+    bot.add_view(YoutubeTrackingRemoverView(bot))
+
+
+class YoutubeTrackingRemover(commands.Cog):
+    def __init__(self, bot: Gunibot):
+        self.bot = bot
+        self.file = "youtubeTrackingRemover"
+        self.cache = {}
+        self.bot.get_command("config").add_command(self.config_enable_youtube_tracking_remover)
+
+    @commands.command(name="enable_youtube_tracking_remover")
+    async def config_enable_youtube_tracking_remover(self, ctx: MyContext, value: bool):
+        """Enable or disable the YouTube tracking remover"""
+        await ctx.send(
+            await self.bot.sconfig.edit_config(ctx.guild.id, "enable_youtube_tracking_remover", value)
+        )
+
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message):
+        # obviously, not in DMs
+        if not message.guild:
+            return
+
+        # check if server has enabled the abbreviation explainer
+        if not self.bot.server_configs[message.guild.id].get("enable_youtube_tracking_remover", False):
+            print("not enabled")
+            return
+
+        # check if message is not from a bot
+        if message.author.bot:
+            return
+
+        # check if message contains a youtube.com link
+        regex = r'(https?://(?:www\.)?youtube\.com/watch\?[^\s]+)'
+        matches = re.findall(regex, message.content)
+        print(matches)
+
+        content = message.content
+        for matche in matches:
+            parsed_url = urlparse(matche)
+            query_params = parse_qs(parsed_url.query)
+
+            # replace the link with a link without tracking
+            if 'v' in query_params:
+                video_id = query_params['v'][0]
+                content = content.replace(matche, f'https://www.youtube.com/watch?v={video_id}')
+
+        # check for youtu.be links
+        regex = r'(https?://(?:www\.)?youtu\.be/[^\s]+)'
+        matches = re.findall(regex, message.content)
+        print(matches)
+
+        for matche in matches:
+            # remove every parameters since youtu.be do not use parameters for video id
+            content = content.replace(matche, f'{matche.split("?")[0]}')
+
+        if content == message.content:
+            # no need to send a message if it will be the same
+            return
+
+        # create a webhook
+        webhook = await message.channel.create_webhook(name="Youtube Tracking Remover")
+
+        # send the message with the replaced links
+        await webhook.send(content,
+                           username=message.author.display_name,
+                           avatar_url=message.author.display_avatar.url,
+                           files=[await attachment.to_file() for attachment in message.attachments],
+                           view=YoutubeTrackingRemoverView(self.bot))
+
+        # delete the original message
+        await message.delete()
+
+        # delete the webhook
+        await webhook.delete()
+
+
+class YoutubeTrackingRemoverView(discord.ui.View):
+    def __init__(self, bot: Gunibot):
+        super().__init__(timeout=None)
+        self.bot = bot
+
+    @discord.ui.button(emoji='❓', style=discord.ButtonStyle.green, custom_id="youtube_tracking_remover:button")
+    async def button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.send_message(await self.bot._(interaction.guild_id, "youtube_tracking_remover.message"),
+                                                ephemeral=True)

--- a/plugins/youtubeTrackingRemover/youtubeTrackingRemover.py
+++ b/plugins/youtubeTrackingRemover/youtubeTrackingRemover.py
@@ -55,23 +55,42 @@ class YoutubeTrackingRemover(commands.Cog):
         print(matches)
 
         content = message.content
-        for matche in matches:
-            parsed_url = urlparse(matche)
+        for match in matches:
+            parsed_url = urlparse(match)
             query_params = parse_qs(parsed_url.query)
 
-            # replace the link with a link without tracking
+            # replace the link with a link with only the video id
             if 'v' in query_params:
                 video_id = query_params['v'][0]
-                content = content.replace(matche, f'https://www.youtube.com/watch?v={video_id}')
+                content = content.replace(match, f'https://www.youtube.com/watch?v={video_id}')
+
+            # re-add `time` and `t` parameters
+            if 't' in query_params:
+                time = query_params['t'][0]
+                content = content.replace(match, f'{match}&t={time}')
+            elif 'time' in query_params:
+                time = query_params['time'][0]
+                content = content.replace(match, f'{match}&time={time}')
 
         # check for youtu.be links
         regex = r'(https?://(?:www\.)?youtu\.be/[^\s]+)'
         matches = re.findall(regex, message.content)
         print(matches)
 
-        for matche in matches:
-            # remove every parameters since youtu.be do not use parameters for video id
-            content = content.replace(matche, f'{matche.split("?")[0]}')
+        for match in matches:
+            parsed_url = urlparse(match)
+            query_params = parse_qs(parsed_url.query)
+
+            # remove every parameters
+            match = match.split('?')[0]
+
+            # re-add `time` and `t` parameters
+            if 't' in query_params:
+                time = query_params['t'][0]
+                content = content.replace(match, f'{match}?t={time}')
+            elif 'time' in query_params:
+                time = query_params['time'][0]
+                content = content.replace(match, f'{match}?time={time}')
 
         if content == message.content:
             # no need to send a message if it will be the same


### PR DESCRIPTION
Ce plugin remplace les messages envoyés et contenant un lien YouTube avec des paramètres

![image](https://github.com/Curiosity-org/Gipsy/assets/29739547/fcba9e56-7ab6-4467-b83a-3e391b2449e4)

Fonctionne sur activation de l'option de config serveur `enable_youtube_tracking_remover`

Le bouton "?" affiche un petit texte explicatif localisé :
![image](https://github.com/Curiosity-org/Gipsy/assets/29739547/934de695-1424-4af1-a81c-840f85776515)
![image](https://github.com/Curiosity-org/Gipsy/assets/29739547/3b5d9bf4-1273-428a-927c-fdbcd9408115)